### PR TITLE
zosmf auth was broken due to promises being incorrectly used

### DIFF
--- a/lib/zosmfAuth.js
+++ b/lib/zosmfAuth.js
@@ -7,6 +7,8 @@
   
   Copyright Contributors to the Zowe Project.
 */
+const Promise = require('bluebird');
+
 const loginUrl = '/zosmf/workflow/rest/1.0/workflows';
 
 const DEFAULT_EXPIRATION_MS = 29700000; //495 minutes, according to zosmf configuration docs
@@ -103,13 +105,15 @@ ZosmfAuthenticator.prototype = {
    * { success: true }. Should not reject the promise.
    */ 
   authenticate(request, sessionState) {
-    this._authenticateOrRefresh(request, sessionState, false).catch((e)=> {
+    return this._authenticateOrRefresh(request, sessionState, false).catch((e)=> {
+      //wary of printing entire error in case it could log a password
+      console.warn(`zosmf-auth authenticate error=${e.message}`);
+      e.stack();
       sessionState.authenticated = false;
       delete sessionState.zosmfUsername;
       delete sessionState.zosmfCookies;
       return { 
-        success: false, 
-        error: e
+        success: false
       };
     });
   },

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -3,7 +3,7 @@
   "pluginType": "nodeAuthentication",
   "authenticationCategory": "zosmf",
   "apiVersion": "1.0.0",
-  "pluginVersion": "0.9.0",
+  "pluginVersion": "0.9.1",
   "filename": "zosmfAuth.js",
   "dataServices": [
     {


### PR DESCRIPTION
This could not run since https://github.com/zowe/zosmf-auth/commit/0cb37f92c611c068e38fc1f112b3928385819c95
Trying to login to the desktop would throw an exception due to yielding being incorrect (incorrect promise use)
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>