### PR TITLE
Added capabilities structure to constructor and getter for capabilities

### DIFF
--- a/lib/zosmfAuth.js
+++ b/lib/zosmfAuth.js
@@ -16,9 +16,20 @@ const DEFAULT_EXPIRATION_MS = 29700000; //495 minutes, according to zosmf config
 function ZosmfAuthenticator(pluginDef, pluginConf, serverConf) {
   this.authPluginID = pluginDef.identifier;
   this.sessionExpirationMS = DEFAULT_EXPIRATION_MS; //according to zosmf configuration docs
+  this.capabilities = {
+    "canGetStatus": true,
+    "canRefresh": false,
+    "canAuthenticate": true,
+    "canAuthorize": true,
+    "proxyAuthorizations": true
+  };
 }
 
 ZosmfAuthenticator.prototype = {
+
+  getCapabilities(){
+    return this.capabilities;
+  },
 
   getStatus(sessionState) {
     const expms = sessionState.sessionExpTime - Date.now();


### PR DESCRIPTION
Used by server framework to determine the capabilities of an authentication handler when calling authenticate() or refreshStatus() functions.
Signed-off-by: Timothy Gerstel tgerstel@rocketsoftware.com